### PR TITLE
Keep default number of links for chrome extension

### DIFF
--- a/ChromeExtension/js/lastLinksViewModel.js
+++ b/ChromeExtension/js/lastLinksViewModel.js
@@ -17,7 +17,7 @@ function lastLinksViewModel() {
 
     var client = new GeniusLinkServiceClient('https://api.geni.us/v1', localStorage['apiKey'], localStorage['apiSecret']);
 
-    client.getFromService('links/list' + '?groupid=' + localStorage['defaultGroupId'] + '&numberoflinks=5', {
+    client.getFromService('links/list' + '?groupid=' + localStorage['defaultGroupId'] + '&take=5', {
         format: 'jsv'
     }, function (resp) {
         var results = resp['Results'];


### PR DESCRIPTION
this bug ticket: https://www.pivotaltracker.com/story/show/168097870 about a change that I made in the links/list api endpoint makes me think about other apps that might be using that endpoint (that's not in the 'core' repo), so making this change.